### PR TITLE
` stage0`: use checkout instead of hard reset

### DIFF
--- a/stage0-binutils.sh
+++ b/stage0-binutils.sh
@@ -10,7 +10,7 @@ BRANCH_NAME="binutils-2_38"
 if test ! -d "$REPO_FOLDER"; then
 	git clone --depth 1 -b $BRANCH_NAME $REPO_URL && cd $REPO_FOLDER || exit 1
 else
-	cd $REPO_FOLDER && git fetch origin && git reset --hard origin/${BRANCH_NAME} || exit 1
+	cd $REPO_FOLDER && git fetch origin && git checkout ${BRANCH_NAME} || exit 1
 fi	
 	
 TARGET="x86_64-pc-freebsd9"


### PR DESCRIPTION
Fixes for WSL
```
Already up to date.
HEAD is now at 77b0629 Merge pull request #2 from orbisdev/upgrading-binutils
fatal: ambiguous argument 'origin/binutils-2_38': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
../scripts/001-toolchain.sh: Failed.
```